### PR TITLE
Listen to treasury.Proposed event and send push notification to respe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 log/*
 *.db
 .env
+.idea

--- a/src/chain/config.ts
+++ b/src/chain/config.ts
@@ -1,16 +1,34 @@
+import * as admin from "firebase-admin";
+import { Event } from "@polkadot/types/interfaces";
+
+export type InterestedEvent = { pattern: string, getPushData: (event: Event) => admin.messaging.TopicMessage };
+
 const kusamaNetwork = {
-  ws: 'wss://kusama.api.onfinality.io/public-ws',
-  events: [],
+  ws: "wss://kusama.api.onfinality.io/public-ws",
+  events: [] as InterestedEvent []
 } as const;
 
 const polkadotNetwork = {
-  ws: 'wss://rpc.polkadot.io',
-  events: [],
+  ws: "wss://rpc.polkadot.io",
+  events: [] as InterestedEvent[]
 } as const;
 
 const litentryNetwork = {
-  ws: 'wss://3.0.201.137',
-  events: [],
+  // ws: 'wss://3.0.201.137',
+  ws: "wss://staging.registrar.litentry.io",
+  events: [{
+    pattern: "treasury.Proposed",
+    getPushData() {
+      return {
+        topic: "treasury.Proposed",
+        data: { deeplink: "litentry://treasury" },
+        notification: {
+          title: `New Treasury Proposal`,
+          body: "A new treasury proposal has been submitted, check it out!"
+        }
+      };
+    }
+  }] as InterestedEvent[]
 } as const;
 
 export type ChainConfig = typeof kusamaNetwork | typeof polkadotNetwork | typeof litentryNetwork;
@@ -18,5 +36,6 @@ export type ChainConfig = typeof kusamaNetwork | typeof polkadotNetwork | typeof
 export default {
   kusama: kusamaNetwork,
   polkadot: polkadotNetwork,
-  litentry_test: litentryNetwork,
+  litentry_test: litentryNetwork
 };
+

--- a/src/chain/config.ts
+++ b/src/chain/config.ts
@@ -21,7 +21,7 @@ const litentryNetwork = {
     getPushData() {
       return {
         topic: "treasury.Proposed",
-        data: { deeplink: "litentry://treasury" },
+        data: { deeplink: "litentry://api/litentry_test/treasury" },
         notification: {
           title: `New Treasury Proposal`,
           body: "A new treasury proposal has been submitted, check it out!"

--- a/src/chain/config.ts
+++ b/src/chain/config.ts
@@ -3,17 +3,22 @@ import { Event } from "@polkadot/types/interfaces";
 
 export type InterestedEvent = { pattern: string, getPushData: (event: Event) => admin.messaging.TopicMessage };
 
-const kusamaNetwork = {
+export type ChainConfig = {
+  ws: string;
+  events: readonly InterestedEvent[]
+}
+
+const kusamaNetwork: ChainConfig = {
   ws: "wss://kusama.api.onfinality.io/public-ws",
-  events: [] as InterestedEvent []
-} as const;
+  events: [],
+} as const
 
-const polkadotNetwork = {
+const polkadotNetwork: ChainConfig = {
   ws: "wss://rpc.polkadot.io",
-  events: [] as InterestedEvent[]
-} as const;
+  events: [],
+} as const
 
-const litentryNetwork = {
+const litentryNetwork: ChainConfig = {
   // ws: 'wss://3.0.201.137',
   ws: "wss://staging.registrar.litentry.io",
   events: [{
@@ -28,10 +33,9 @@ const litentryNetwork = {
         }
       };
     }
-  }] as InterestedEvent[]
-} as const;
+  }]
+}
 
-export type ChainConfig = typeof kusamaNetwork | typeof polkadotNetwork | typeof litentryNetwork;
 
 export default {
   kusama: kusamaNetwork,


### PR DESCRIPTION
Listen to `treasury.Proposed` event and send push notification to the respective topic.

config is changed a bit to give us the ability to react differently to events on different servers.

fixes https://github.com/litentry/litentry-app/issues/159